### PR TITLE
removed reattach to user namespace

### DIFF
--- a/tmux/my-tmux.conf
+++ b/tmux/my-tmux.conf
@@ -54,9 +54,8 @@ bind-key -T copy-mode-vi V send -X select-line
 # C-vで矩形選択の切り替え
 bind-key -T copy-mode-vi C-v send -X rectangle-toggle
 
-# Sierra から pbcopy が動かなく... http://qiita.com/tchssk/items/de7a0323307c35c54a97
-set -g default-command "reattach-to-user-namespace -l ${SHELL}"
-bind-key -T copy-mode-vi y send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+# pbcopy > 2.6 https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/issues/66
+bind-key -T copy-mode C-\ send-keys -X copy-pipe-and-cancel "pbcopy"
 
 # | でペインを縦に分割する
 bind | split-window -h

--- a/tmux/setup_tmux.sh
+++ b/tmux/setup_tmux.sh
@@ -3,11 +3,10 @@
 UNAME_S=$(uname -s)
 if [ "${UNAME_S}" = "Darwin" ] ; then
 	brew install tmux
-  brew install reattach-to-user-namespace
 elif [ "${UNAME_S}" = "Linux" ]; then
   #TODO: fix installing new tmux
   sudo yum -y install gcc libevent-devel ncurses-devel
-	TMUX_VER="2.4"
+	TMUX_VER="2.6"
 	TMUX_STR="tmux-${TMUX_VER}"
 	wget https://github.com/tmux/tmux/releases/download/${TMUX_VER}/${TMUX_STR}.tar.gz
 	tar xvf ${TMUX_STR}.tar.gz


### PR DESCRIPTION
## Notes
If you use Mohave and tmux >= 2.6 then you don't need reattach to user namespace

https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/issues/66