### PR TITLE
Update tmux conf (uninstall reattach-to-user-namespace)

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -3,3 +3,5 @@ source-file ~/dotfiles/tmux/settings.conf
 source-file ~/dotfiles/tmux/visuals.conf
 source-file ~/dotfiles/tmux/keybindings.conf
 source-file ~/dotfiles/tmux/plugins.conf
+
+if-shell "uname | grep -q Darwin" "source-file ~/dotfiles/tmux/macos.conf" ""

--- a/tmux/macos.conf
+++ b/tmux/macos.conf
@@ -1,0 +1,3 @@
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"

--- a/tmux/settings.conf
+++ b/tmux/settings.conf
@@ -1,7 +1,6 @@
 # enable mouse tmux >= 2.1
-set-option -g mouse on
-bind-key WheelUpPane send-keys -X scroll-up
-bind-key WheelDownPane send-keys -X scroll-down
+# in iTerm2, you need to enable "mouse reporting" in Profile
+set -g mouse on
 
 # escape key recognition delay to 0
 set -s escape-time 0

--- a/tmux/settings.conf
+++ b/tmux/settings.conf
@@ -1,2 +1,7 @@
 # enable mouse tmux >= 2.1
 set-option -g mouse on
+bind-key WheelUpPane send-keys -X scroll-up
+bind-key WheelDownPane send-keys -X scroll-down
+
+# escape key recognition delay to 0
+set -s escape-time 0

--- a/tmux/setup.sh
+++ b/tmux/setup.sh
@@ -9,7 +9,6 @@ if ! hash tmux 2>/dev/null; then
 	case "${os}" in
 	"MacOS")
 		brew install tmux
-		brew install reattach-to-user-namespace
 		;;
 	"CentOS")
 		declare TMUX_VERSION="2.8"

--- a/tmux/visuals.conf
+++ b/tmux/visuals.conf
@@ -1,35 +1,37 @@
-# status bar position 
+# message text
+set-option -g message-style bg=black,fg=brightred
+
+# Status bar style
 set-option -g status-position top
-# allow status left length to 20
-set-option -g status-left-length 20
-# #H machine name, #I window idx, #P pane idx
+# allow status bar length to 20
+set-option -g status-left-length 30
+# information shown in status bar: #H machine name, #I window idx, #P pane idx
 set-option -g status-left '#H'
 # title length to 8 
 set-option -gw window-status-format "#I:#{=8:window_name}#F"
-
-setw -g window-status-style fg=white,bg=red
-setw -g window-status-style bright,dim
-
-# start window index from 1
-set -g base-index 1
-# clock
-set-window-option -g clock-mode-colour green
-# bell
-set-window-option -g window-status-bell-style fg=black,bg=red
-
-# Color settings
 # default statusbar colors
 set-option -g status-style fg=yellow,bg=black
+
+# Window status style
+# start window index from 1
+set -g base-index 1
 # default window title colors
 set-window-option -g window-status-style fg=brightblue,bg=default,dim
 # active window title colors
 set-window-option -g window-status-current-style fg=brightred,bg=default
+# bell style
+set-window-option -g window-status-bell-style fg=black,bg=red
+
+# Window style
+# stand out active window
+set -g window-style 'bg=colour234'
+set -g window-active-style 'bg=colour232'
+# clock style
+set-window-option -g clock-mode-colour green
+
+# Pane style
 # pane border
-set-option -g pane-border-style fg=black
 set-option -g pane-active-border-style fg=brightgreen
-# message text
-set-option -g message-style bg=black,fg=brightred
 # pane number display
 set-option -g display-panes-active-colour blue
 set-option -g display-panes-colour brightred
-


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- want to remove unnecessary plugins

## What
<!-- What features are added in this PR -->
- uninstall reattach-to-user-namespace (was useful in tmux 2.x 🙏 )
- stand out active pane

## QA, Evidence
<!-- Things that support this PR is correct -->

![image](https://user-images.githubusercontent.com/1454332/144740220-c5758679-6aa5-4376-a7ae-b4963390b634.png)
