### PR TITLE
install tailscale on linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -364,6 +364,7 @@ linux_setup_personal_machine_tools() {
     log "$LOG_LEVEL_INFO" "[ ] tailscale not installed. Installing..."
     curl -fsSL https://tailscale.com/install.sh | sh
     log "$LOG_LEVEL_INFO" "[✓] tailscale install finished"
+    sudo tailscale up
 }
 
 setup_zsh() {

--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,19 @@ setup_personal_machine_tools() {
     fi
 }
 
+linux_setup_personal_machine_tools() {
+    echo_blue "Setup personal machine tools for linux..."
+
+    if hash tailscale 2>/dev/null; then
+        log "$LOG_LEVEL_INFO" "[✓] tailscale is already installed"
+        return
+    fi
+    log "$LOG_LEVEL_INFO" "[ ] tailscale not installed. Installing..."
+    curl -fsSL https://tailscale.com/install.sh | sh
+    log "$LOG_LEVEL_INFO" "[✓] tailscale install finished"
+
+}
+
 setup_zsh() {
     echo_blue "Setup zsh..."
 

--- a/install.sh
+++ b/install.sh
@@ -364,7 +364,6 @@ linux_setup_personal_machine_tools() {
     log "$LOG_LEVEL_INFO" "[ ] tailscale not installed. Installing..."
     curl -fsSL https://tailscale.com/install.sh | sh
     log "$LOG_LEVEL_INFO" "[✓] tailscale install finished"
-
 }
 
 setup_zsh() {
@@ -454,7 +453,7 @@ case "${os}" in
     homebrew_bin_path="/home/linuxbrew/.linuxbrew/bin"
     setup_package_manager
     setup_basic_tools
-    setup_personal_machine_tools
+    setup_personal_machine_tools linux_setup_personal_machine_tools
     setup_zsh
     setup_vim
     setup_tmux

--- a/install.sh
+++ b/install.sh
@@ -364,9 +364,8 @@ linux_setup_personal_machine_tools() {
     log "$LOG_LEVEL_INFO" "[ ] tailscale not installed. Installing..."
     curl -fsSL https://tailscale.com/install.sh | sh
     log "$LOG_LEVEL_INFO" "[✓] tailscale install finished"
-    set +e
-    sudo tailscale up
-    set -e
+
+    echo_green "run 'sudo tailscale up' for joining to tailscale network"
 }
 
 setup_zsh() {

--- a/install.sh
+++ b/install.sh
@@ -364,7 +364,9 @@ linux_setup_personal_machine_tools() {
     log "$LOG_LEVEL_INFO" "[ ] tailscale not installed. Installing..."
     curl -fsSL https://tailscale.com/install.sh | sh
     log "$LOG_LEVEL_INFO" "[✓] tailscale install finished"
+    set +e
     sudo tailscale up
+    set -e
 }
 
 setup_zsh() {


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- I want to install tailscale to all personal machines

## What
<!-- What features are added in this PR -->
- In macos, install tailscale GUI via homebrew
- In linux, install tailscale using script. (homebrew version of tailscale cli does not include tailscaled)
