### PR TITLE
Manage Claude read-only command permissions in dotfiles

### DIFF
--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -1,0 +1,35 @@
+name: Scripts Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - "scripts/**"
+      - "install.sh"
+      - "claude/**"
+      - ".github/workflows/scripts-test.yml"
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - "scripts/**"
+      - "install.sh"
+      - "claude/**"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # jq is preinstalled on GitHub-hosted ubuntu runners; the tests need
+      # nothing else (no bats or other test framework).
+      - name: Run script tests
+        run: |
+          for t in scripts/test/*_test.sh; do
+            echo "== ${t} =="
+            bash "${t}"
+          done

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,35 @@
+name: ShellCheck
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - "**/*.sh"
+      - ".github/workflows/shellcheck.yml"
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - "**/*.sh"
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: |
+          # Own scripts only; skip vendored plugins under terminal-tools/.
+          # -x follows `source` so sourced globals resolve and SC1091 is quiet.
+          mapfile -t files < <(git ls-files '*.sh' | grep -v '^terminal-tools/')
+          echo "Checking: ${files[*]}"
+          rc=0
+          for f in "${files[@]}"; do
+            shellcheck -x "$f" || rc=1
+          done
+          exit "$rc"

--- a/claude/settings.permissions.json
+++ b/claude/settings.permissions.json
@@ -1,0 +1,35 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(fd:*)",
+      "Bash(tree:*)",
+      "Bash(wc:*)",
+      "Bash(file:*)",
+      "Bash(stat:*)",
+      "Bash(du:*)",
+      "Bash(df:*)",
+      "Bash(pwd)",
+      "Bash(which:*)",
+      "Bash(whoami)",
+      "Bash(uname:*)",
+      "Bash(date)",
+      "Bash(echo:*)",
+      "Bash(env)",
+      "Bash(jq:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git blame:*)"
+    ]
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -440,23 +440,11 @@ setup_claude_permissions() {
 
     cp "${settings}" "${settings}.$(date '+%Y%m%d-%H%M%S').bk"
 
-    # Deep-merge the permissions block: preserve every existing top-level key
-    # and take the union of the allow/deny/ask lists (empty lists are dropped).
+    # Deep-merge the permissions block (logic lives in a testable helper).
     local tmp
     tmp="$(mktemp)"
-    jq -n --slurpfile cur "${settings}" --slurpfile new "${perm_src}" '
-        ($cur[0] // {}) as $c
-        | ($new[0] // {}) as $n
-        | ($c.permissions // {}) as $cp
-        | ($n.permissions // {}) as $np
-        | ($cp * $np
-            | .allow = (($cp.allow // []) + ($np.allow // []) | unique)
-            | .deny  = (($cp.deny  // []) + ($np.deny  // []) | unique)
-            | .ask   = (($cp.ask   // []) + ($np.ask   // []) | unique)
-            | with_entries(select(.value | (type != "array") or (length > 0)))
-          ) as $mp
-        | $c * { permissions: $mp }
-    ' >"${tmp}" && mv "${tmp}" "${settings}"
+    ./scripts/merge-claude-permissions.sh "${settings}" "${perm_src}" >"${tmp}" \
+        && mv "${tmp}" "${settings}"
 
     log "$LOG_LEVEL_INFO" "[✓] patched claude permissions in ${settings}"
 }

--- a/install.sh
+++ b/install.sh
@@ -409,7 +409,54 @@ setup_claude_code() {
     apm install "${apm_pkg_dir}" --global --target claude
     apm compile --global
 
+    # apm has no primitive for tool permissions, so manage the `permissions`
+    # block of ~/.claude/settings.json here instead.
+    setup_claude_permissions
+
     log "$LOG_LEVEL_INFO" "[✓] claude-code install finished"
+}
+
+# Deploy the read-only command allowlist into ~/.claude/settings.json.
+# If the file exists, back it up (datetime suffix) and merge only the
+# `permissions` block in; otherwise write the permissions file as-is.
+setup_claude_permissions() {
+    brew_install jq
+
+    local perm_src="$(pwd)/claude/settings.permissions.json"
+    local settings="${home_dir}/.claude/settings.json"
+
+    if [ ! -f "${perm_src}" ]; then
+        log "$LOG_LEVEL_WARN" "[ ] ${perm_src} not found, skip claude permissions"
+        return
+    fi
+
+    if [ ! -f "${settings}" ]; then
+        cp "${perm_src}" "${settings}"
+        log "$LOG_LEVEL_INFO" "[✓] wrote claude permissions to ${settings}"
+        return
+    fi
+
+    cp "${settings}" "${settings}.$(date '+%Y%m%d-%H%M%S').bk"
+
+    # Deep-merge the permissions block: preserve every existing top-level key
+    # and take the union of the allow/deny/ask lists (empty lists are dropped).
+    local tmp
+    tmp="$(mktemp)"
+    jq -n --slurpfile cur "${settings}" --slurpfile new "${perm_src}" '
+        ($cur[0] // {}) as $c
+        | ($new[0] // {}) as $n
+        | ($c.permissions // {}) as $cp
+        | ($n.permissions // {}) as $np
+        | ($cp * $np
+            | .allow = (($cp.allow // []) + ($np.allow // []) | unique)
+            | .deny  = (($cp.deny  // []) + ($np.deny  // []) | unique)
+            | .ask   = (($cp.ask   // []) + ($np.ask   // []) | unique)
+            | with_entries(select(.value | (type != "array") or (length > 0)))
+          ) as $mp
+        | $c * { permissions: $mp }
+    ' >"${tmp}" && mv "${tmp}" "${settings}"
+
+    log "$LOG_LEVEL_INFO" "[✓] patched claude permissions in ${settings}"
 }
 
 setup_zellij() {

--- a/install.sh
+++ b/install.sh
@@ -405,7 +405,8 @@ setup_claude_code() {
     mkdir -p "${home_dir}/.claude"
 
     # apm rejects relative paths at user scope, so resolve an absolute path.
-    local apm_pkg_dir="$(pwd)/apm"
+    local apm_pkg_dir
+    apm_pkg_dir="$(pwd)/apm"
     apm install "${apm_pkg_dir}" --global --target claude
     apm compile --global
 
@@ -422,8 +423,9 @@ setup_claude_code() {
 setup_claude_permissions() {
     brew_install jq
 
-    local perm_src="$(pwd)/claude/settings.permissions.json"
-    local settings="${home_dir}/.claude/settings.json"
+    local perm_src settings
+    perm_src="$(pwd)/claude/settings.permissions.json"
+    settings="${home_dir}/.claude/settings.json"
 
     if [ ! -f "${perm_src}" ]; then
         log "$LOG_LEVEL_WARN" "[ ] ${perm_src} not found, skip claude permissions"

--- a/os-linux/setup.sh
+++ b/os-linux/setup.sh
@@ -27,6 +27,7 @@ linux_setup_personal_machine_tools() {
         log "$LOG_LEVEL_INFO" "[✓] google-cloud-sdk is already installed"
     else
         log "$LOG_LEVEL_INFO" "[ ] google-cloud-sdk not installed. Installing..."
+        # shellcheck disable=SC2154 # os is provided by install.sh, which sources this file
         case "${os}" in
         "ubuntu")
             sudo snap install google-cloud-cli --classic

--- a/os-macos/setup.sh
+++ b/os-macos/setup.sh
@@ -18,6 +18,7 @@ macos_setup_basic_tools() {
 
     setup_karabiner
     # TIPS: installing tools with Homebrew takes a long time in CI so skip for these tools
+    # shellcheck disable=SC2154 # is_ci is provided by install.sh, which sources this file
     if [ "${is_ci}" = "false" ]; then
         brew_install watch
         brew install --cask appcleaner
@@ -80,7 +81,7 @@ macos_setup_defaults() {
     # change caps lock to control
     # get string like : 1452-630-0 for keyboard_id (ref: http://freewing.starfree.jp/software/macos_keyboard_setting_terminal_commandline)
     keyboard_id="$(ioreg -c AppleEmbeddedKeyboard -r | grep -Eiw "VendorID|ProductID" | awk '{ print $4 }' | paste -s -d'-\n' -)-0"
-    defaults -currentHost write -g com.apple.keyboard.modifiermapping.${keyboard_id} -array-add "
+    defaults -currentHost write -g "com.apple.keyboard.modifiermapping.${keyboard_id}" -array-add "
 <dict>
   <key>HIDKeyboardModifierMappingDst</key>\
   <integer>30064771300</integer>\

--- a/scripts/merge-claude-permissions.sh
+++ b/scripts/merge-claude-permissions.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Merge a Claude permissions file into an existing settings.json and print the
+# result to stdout. Pure (no side effects) so it can be unit tested directly.
+#
+# Usage: merge-claude-permissions.sh <current-settings.json> <permissions.json>
+#
+# Semantics:
+#   - every existing top-level key in the current settings is preserved
+#   - the allow/deny/ask lists under .permissions are unioned (deduped)
+#   - empty permission lists are dropped rather than written back as []
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $(basename "$0") <current-settings.json> <permissions.json>" >&2
+    exit 2
+fi
+
+current="$1"
+incoming="$2"
+
+jq -n --slurpfile cur "${current}" --slurpfile new "${incoming}" '
+    ($cur[0] // {}) as $c
+    | ($new[0] // {}) as $n
+    | ($c.permissions // {}) as $cp
+    | ($n.permissions // {}) as $np
+    | ($cp * $np
+        | .allow = (($cp.allow // []) + ($np.allow // []) | unique)
+        | .deny  = (($cp.deny  // []) + ($np.deny  // []) | unique)
+        | .ask   = (($cp.ask   // []) + ($np.ask   // []) | unique)
+        | with_entries(select(.value | (type != "array") or (length > 0)))
+      ) as $mp
+    | $c * { permissions: $mp }
+'

--- a/scripts/test/merge-claude-permissions_test.sh
+++ b/scripts/test/merge-claude-permissions_test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Plain-bash tests for scripts/merge-claude-permissions.sh.
+# No test framework: only bash + jq (which install.sh already requires).
+#
+# Run: ./scripts/test/merge-claude-permissions_test.sh
+# Exits non-zero if any case fails.
+
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+merge="${script_dir}/../merge-claude-permissions.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+pass=0
+fail=0
+
+# Compare two JSON strings after canonical sorting so key/array order and
+# whitespace do not matter.
+assert_json_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    local e a
+    e="$(printf '%s' "${expected}" | jq -S . 2>/dev/null)"
+    a="$(printf '%s' "${actual}" | jq -S . 2>/dev/null)"
+    if [ "${e}" = "${a}" ]; then
+        pass=$((pass + 1))
+        echo "ok   - ${desc}"
+    else
+        fail=$((fail + 1))
+        echo "FAIL - ${desc}"
+        echo "  expected: ${e}"
+        echo "  actual:   ${a}"
+    fi
+}
+
+assert_exit() {
+    local desc="$1" want="$2" got="$3"
+    if [ "${want}" = "${got}" ]; then
+        pass=$((pass + 1))
+        echo "ok   - ${desc}"
+    else
+        fail=$((fail + 1))
+        echo "FAIL - ${desc} (want exit ${want}, got ${got})"
+    fi
+}
+
+# Helper: write $1 to a temp file and echo its path.
+mkjson() {
+    local f
+    f="$(mktemp "${work}/XXXXXX.json")"
+    printf '%s' "$1" >"${f}"
+    printf '%s' "${f}"
+}
+
+incoming='{"permissions":{"allow":["Bash(ls:*)","Bash(cat:*)"]}}'
+
+# --- Case 1: preserve other top-level keys, union allow, keep deny --------
+cur="$(mkjson '{"model":"x","env":{"A":"1"},"permissions":{"allow":["Bash(mycmd:*)"],"deny":["Bash(rm:*)"]}}')"
+inc="$(mkjson "${incoming}")"
+out="$("${merge}" "${cur}" "${inc}")"
+assert_json_eq "preserves top-level keys and unions allow, keeps deny" \
+    '{"model":"x","env":{"A":"1"},"permissions":{"allow":["Bash(cat:*)","Bash(ls:*)","Bash(mycmd:*)"],"deny":["Bash(rm:*)"]}}' \
+    "${out}"
+
+# --- Case 2: deduplicate overlapping allow entries -----------------------
+cur="$(mkjson '{"permissions":{"allow":["Bash(ls:*)","Bash(cat:*)"]}}')"
+out="$("${merge}" "${cur}" "${inc}")"
+assert_json_eq "deduplicates overlapping allow entries" \
+    '{"permissions":{"allow":["Bash(cat:*)","Bash(ls:*)"]}}' \
+    "${out}"
+
+# --- Case 3: empty current object gets incoming permissions --------------
+cur="$(mkjson '{}')"
+out="$("${merge}" "${cur}" "${inc}")"
+assert_json_eq "empty settings receives incoming permissions" \
+    '{"permissions":{"allow":["Bash(cat:*)","Bash(ls:*)"]}}' \
+    "${out}"
+
+# --- Case 4: current without a permissions key ---------------------------
+cur="$(mkjson '{"model":"y"}')"
+out="$("${merge}" "${cur}" "${inc}")"
+assert_json_eq "adds permissions when absent, keeps existing keys" \
+    '{"model":"y","permissions":{"allow":["Bash(cat:*)","Bash(ls:*)"]}}' \
+    "${out}"
+
+# --- Case 5: no empty ask/deny arrays are injected -----------------------
+cur="$(mkjson '{"permissions":{"allow":["Bash(ls:*)"]}}')"
+out="$("${merge}" "${cur}" "${inc}")"
+has_ask="$(printf '%s' "${out}" | jq 'has("permissions") and (.permissions | has("ask") or has("deny"))')"
+assert_json_eq "does not inject empty ask/deny arrays" "false" "${has_ask}"
+
+# --- Case 6: idempotent (merging the result again is a no-op) ------------
+first="$(mkjson "${out}")"
+out2="$("${merge}" "${first}" "${inc}")"
+assert_json_eq "merge is idempotent" "${out}" "${out2}"
+
+# --- Case 7: wrong argument count exits 2 --------------------------------
+"${merge}" "${cur}" >/dev/null 2>&1
+assert_exit "errors on wrong argument count" "2" "$?"
+
+echo "-----------------------------------------"
+echo "passed: ${pass}, failed: ${fail}"
+[ "${fail}" -eq 0 ]


### PR DESCRIPTION
apm has no primitive for tool permissions, so keep the read-only
command allowlist in claude/settings.permissions.json and deploy it
from install.sh: back up an existing ~/.claude/settings.json with a
datetime suffix and deep-merge the permissions block (union of the
allow/deny/ask lists, all other keys preserved), or write the file
verbatim when none exists.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CZ9q6Wk1qUaVP6UbEevASY